### PR TITLE
Set request headers safely

### DIFF
--- a/projects/ngx-hal/src/lib/classes/hal-storage/etag-hal-storage.ts
+++ b/projects/ngx-hal/src/lib/classes/hal-storage/etag-hal-storage.ts
@@ -3,6 +3,7 @@ import { HalDocument } from './../hal-document';
 import { HttpResponse } from '@angular/common/http';
 import { RequestOptions } from '../../types/request-options.type';
 import { HalStorage } from './hal-storage';
+import { setRequestHeader } from '../../utils/set-request-header/set-request-header.util';
 
 interface StorageModel<T extends HalModel> {
   model: T | HalDocument<T>;
@@ -39,8 +40,7 @@ export class EtagHalStorage extends HalStorage {
     }
 
     if (storageModel.etag) {
-      requestOptions.headers = requestOptions.headers || {};
-      requestOptions.headers['If-None-Match'] = storageModel.etag;
+      requestOptions.headers = setRequestHeader(requestOptions.headers, 'If-None-Match', storageModel.etag);
     }
   }
 

--- a/projects/ngx-hal/src/lib/models/hal.model.ts
+++ b/projects/ngx-hal/src/lib/models/hal.model.ts
@@ -15,13 +15,14 @@ import { NetworkConfig } from '../interfaces/network-config.interface';
 import { generateUUID } from '../helpers/uuid/uuid.helper';
 import { getResponseHeader } from '../utils/get-response-headers/get-response-header.util';
 import { isHalModelInstance } from '../helpers/is-hal-model-instance.ts/is-hal-model-instance.helper';
-import { RequestOptions } from '../types/request-options.type';
+import { PlainHeaders, RequestOptions } from '../types/request-options.type';
 import { ModelProperty as ModelPropertyEnum } from '../enums/model-property.enum';
 import { GeneratePayloadOptions } from '../interfaces/generate-payload-options.interface';
 import { CustomOptions } from '../interfaces/custom-options.interface';
 import { ensureRelationshipRequestDescriptors } from '../utils/ensure-relationship-descriptors/ensure-relationship-descriptors.util';
 import { RelationshipRequestDescriptor } from '../types/relationship-request-descriptor.type';
 import { removeQueryParams } from '../utils/remove-query-params/remove-query-params.util';
+import { setRequestHeader } from '../utils/set-request-header/set-request-header.util';
 
 export abstract class HalModel {
   private config: ModelOptions = this['config'] || DEFAULT_MODEL_OPTIONS;
@@ -251,12 +252,13 @@ export abstract class HalModel {
       }, {});
   }
 
-  public generateHeaders(): object {
-    return this.headerAttributeProperties.reduce((headers: object, property: HeaderAttributeModelProperty) => {
+  public generateHeaders(): PlainHeaders {
+    return this.headerAttributeProperties.reduce((headers: PlainHeaders, property: HeaderAttributeModelProperty) => {
       const externalPropertyName: string = property.externalName;
       const propertyName: string = property.name;
-      headers[externalPropertyName] = property.transformBeforeSave ? property.transformBeforeSave(this[propertyName]) : this[propertyName];
-      return headers;
+      const propertyValue = property.transformBeforeSave ? property.transformBeforeSave(this[propertyName]) : this[propertyName];
+
+      return setRequestHeader(headers, externalPropertyName, propertyValue);
     }, {});
   }
 

--- a/projects/ngx-hal/src/lib/types/request-options.type.ts
+++ b/projects/ngx-hal/src/lib/types/request-options.type.ts
@@ -1,9 +1,11 @@
 import { HttpHeaders, HttpParams } from '@angular/common/http';
 
+export type PlainHeaders = {
+  [header: string]: string | string[];
+};
+
 export type RequestOptions = {
-  headers?: HttpHeaders | {
-    [header: string]: string | string[];
-  };
+  headers?: HttpHeaders | PlainHeaders;
   observe?;
   params?: HttpParams | {
     [param: string]: string | string[];

--- a/projects/ngx-hal/src/lib/utils/set-request-header/set-request-header.util.spec.ts
+++ b/projects/ngx-hal/src/lib/utils/set-request-header/set-request-header.util.spec.ts
@@ -1,0 +1,32 @@
+import { HttpHeaders } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { PlainHeaders } from '../../types/request-options.type';
+import { setRequestHeader } from './set-request-header.util';
+
+describe('setRequestHeader', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should set a new header out of an object', () => {
+    const initialHeaders = { oldHeader: 'oldHeader' };
+    const newHeaders: PlainHeaders = setRequestHeader(initialHeaders, 'newHeader', 'something');
+
+    expect(newHeaders.newHeader).toBeDefined();
+    expect(newHeaders.oldHeader).toBeDefined();
+  });
+
+  it('should not modify an existing headers object when adding a new header', () => {
+    const initialHeaders = { oldHeader: 'oldHeader' };
+    setRequestHeader(initialHeaders, 'newHeader', 'something');
+
+    expect(initialHeaders.oldHeader).toBeDefined();
+    expect(initialHeaders['newHeaders']).not.toBeDefined();
+  });
+
+  it('should set a new header out of a HttpHeader', () => {
+    const initialHeaders = new HttpHeaders({ oldHeader: 'oldHeader' });
+    const newHeaders: HttpHeaders = setRequestHeader(initialHeaders, 'newHeader', 'something');
+
+    expect(newHeaders.get('newHeader')).toBeDefined();
+    expect(newHeaders.get('oldHeader')).toBeDefined();
+  });
+});

--- a/projects/ngx-hal/src/lib/utils/set-request-header/set-request-header.util.ts
+++ b/projects/ngx-hal/src/lib/utils/set-request-header/set-request-header.util.ts
@@ -1,0 +1,52 @@
+import { HttpHeaders } from '@angular/common/http';
+import { PlainHeaders } from '../../types/request-options.type';
+
+export function setRequestHeader<HttpHeaders>(
+  initialHeaders: HttpHeaders,
+  headerName: string,
+  headerValue: string | Array<string>
+): HttpHeaders;
+export function setRequestHeader<PlainHeaders>(
+  initialHeaders: PlainHeaders,
+  headerName: string,
+  headerValue: string | Array<string>
+): PlainHeaders;
+export function setRequestHeader(
+  initialHeaders: HttpHeaders | PlainHeaders,
+  headerName: string,
+  headerValue: string | Array<string>
+): HttpHeaders | PlainHeaders {
+  if (initialHeaders instanceof HttpHeaders) {
+    return setHttpRequestHeader(initialHeaders, headerName, headerValue);
+  }
+
+  return setObjectRequestHeader(initialHeaders, headerName, headerValue);
+}
+
+function setHttpRequestHeader(
+  initialHeaders: HttpHeaders,
+  headerName: string,
+  headerValue: string | Array<string>
+): HttpHeaders {
+  if (headerValue !== undefined || headerValue !== null) {
+    return initialHeaders.append(headerName, headerValue);
+  }
+
+  return initialHeaders;
+}
+
+function setObjectRequestHeader(
+  initialHeaders: PlainHeaders,
+  headerName: string,
+  headerValue: string | Array<string>
+): PlainHeaders {
+  const headers: PlainHeaders = {};
+
+  Object.assign(headers, initialHeaders);
+
+  if (headerValue !== undefined || headerValue !== null) {
+    headers[headerName] = headerValue;
+  }
+
+  return headers;
+}


### PR DESCRIPTION
Added a safety check to avoid setting `undefined`/`null` as a request header.