### PR TITLE
Additional ways of defining model relationships

### DIFF
--- a/projects/ngx-hal/ng-package.json
+++ b/projects/ngx-hal/ng-package.json
@@ -4,7 +4,7 @@
   "lib": {
     "entryFile": "src/public_api.ts"
   },
-  "whitelistedNonPeerDependencies": [
+  "allowedNonPeerDependencies": [
     "deepmerge",
     "uri-templates"
   ]

--- a/projects/ngx-hal/src/lib/interfaces/model-options.interface.ts
+++ b/projects/ngx-hal/src/lib/interfaces/model-options.interface.ts
@@ -12,3 +12,5 @@ export class ModelOptions {
 export const DEFAULT_MODEL_OPTIONS: ModelOptions = {
   type: ''
 };
+
+export const DEFAULT_MODEL_TYPE = '__DEFAULT_MODEL_TYPE__';

--- a/projects/ngx-hal/src/lib/services/datastore/datastore.service.ts
+++ b/projects/ngx-hal/src/lib/services/datastore/datastore.service.ts
@@ -43,10 +43,7 @@ export class DatastoreService {
   public paginationClass: PaginationConstructor;
   public modelTypes: Array<typeof HalModel> = [];
 
-  constructor(public http: HttpClient) {
-    window['x'] = this;
-    console.log('ds');
-  }
+  constructor(public http: HttpClient) {}
 
   private getHalDocumentClass<T extends HalModel>(): HalDocumentConstructor<T> {
     return Reflect.getMetadata(HAL_DATASTORE_DOCUMENT_CLASS_METADATA_KEY, this.constructor) || HalDocument;

--- a/projects/ngx-hal/src/lib/services/datastore/datastore.service.ts
+++ b/projects/ngx-hal/src/lib/services/datastore/datastore.service.ts
@@ -32,6 +32,7 @@ import { RelationshipRequestDescriptor } from '../../types/relationship-request-
 import { ensureRelationshipRequestDescriptors } from '../../utils/ensure-relationship-descriptors/ensure-relationship-descriptors.util';
 import { RelationshipDescriptorMappings } from '../../types/relationship-descriptor-mappings.type';
 import { EMBEDDED_PROPERTY_NAME } from '../../constants/hal.constant';
+import { isString } from '../../utils/is-string/is-string.util';
 
 @Injectable()
 export class DatastoreService {
@@ -40,8 +41,12 @@ export class DatastoreService {
   private internalStorage  = createHalStorage(this.cacheStrategy);
   protected httpParamsOptions?: object;
   public paginationClass: PaginationConstructor;
+  public modelTypes: Array<typeof HalModel> = [];
 
-  constructor(public http: HttpClient) {}
+  constructor(public http: HttpClient) {
+    window['x'] = this;
+    console.log('ds');
+  }
 
   private getHalDocumentClass<T extends HalModel>(): HalDocumentConstructor<T> {
     return Reflect.getMetadata(HAL_DATASTORE_DOCUMENT_CLASS_METADATA_KEY, this.constructor) || HalDocument;
@@ -127,7 +132,12 @@ export class DatastoreService {
         continue;
       }
 
-      const modelClass = property.propertyClass;
+      let modelClass = property.propertyClass;
+
+      if (isString(modelClass)) {
+        modelClass = this.findModelClassByType(modelClass);
+      }
+
       const isSingleResource: boolean = property.type === ModelPropertyEnum.Attribute || property.type === ModelPropertyEnum.HasOne;
 
       // Checks if the relationship is already embdedded inside the emdedded property, or
@@ -879,6 +889,16 @@ export class DatastoreService {
 
   private get cacheStrategy(): CacheStrategy {
     return this._cacheStrategy;
+  }
+
+  public findModelClassByType(modelType: string): typeof HalModel {
+    const modelClass: typeof HalModel = this.modelTypes.find((modelClass) => modelClass.modelType === modelType);
+
+    if (!modelClass) {
+      throw new Error(`Provided model name "${modelType}" cannot be found in the Datastore. Provide it in DatastoreService.modelTypes`);
+    }
+
+    return modelClass;
   }
 
   public createModel<T extends HalModel>(modelClass: ModelConstructor<T>, recordData: object = {}): T {

--- a/projects/ngx-hal/src/lib/utils/is-string/is-string.util.ts
+++ b/projects/ngx-hal/src/lib/utils/is-string/is-string.util.ts
@@ -1,0 +1,3 @@
+export function isString(item: any): boolean {
+  return typeof item === 'string' || item instanceof String;
+}

--- a/projects/ngx-hal/src/lib/utils/is-string/is-string.utils.spec.ts
+++ b/projects/ngx-hal/src/lib/utils/is-string/is-string.utils.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+import { isString } from './is-string.util';
+
+describe('isString', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should return true if a string is passed', () => {
+    expect(isString('some string')).toBeTrue();
+  });
+
+  it('should return true if an empty string is passed', () => {
+    expect(isString('')).toBeTrue();
+  });
+
+  it('should return true if an empty string is passed', () => {
+    expect(isString(new String())).toBeTrue();
+  });
+
+  it('should return false if a number is passed', () => {
+    expect(isString(3)).toBeFalse();
+  });
+
+  it('should return false if an object is passed', () => {
+    expect(isString({})).toBeFalse();
+  });
+});


### PR DESCRIPTION
So far, `propertyClass` property of `Attribute`, `HeaderAttribute`, and `HasOne` decorators accepted classes only. This pull request introduces a new way of defining relationships by provided string identificators. 
In order to use model's string identificator, the said identificator must be set on the model (`modelType` property), and the model must be provided in the list of models present in the DatastoreService (`modelTypes` property). 

Why would you need to use string identificator instead of the exact class? 
In case when two models have references between each other, the reference on one of the sides must be defined via string identificators to break the circular dependency.

https://github.com/infinum/ngx-hal/wiki/DefiningModelRelationships#circular-dependencies