### PR TITLE
Support custom model endpoints

### DIFF
--- a/projects/ngx-hal/src/lib/interfaces/model-endpoints.interface.ts
+++ b/projects/ngx-hal/src/lib/interfaces/model-endpoints.interface.ts
@@ -1,0 +1,4 @@
+export interface ModelEndpoints {
+	singleResourceEndpoint?: string;
+	collectionEndpoint?: string;
+}

--- a/projects/ngx-hal/src/lib/models/hal.model.ts
+++ b/projects/ngx-hal/src/lib/models/hal.model.ts
@@ -45,6 +45,7 @@ import { removeQueryParams } from '../utils/remove-query-params/remove-query-par
 import { setRequestHeader } from '../utils/set-request-header/set-request-header.util';
 import { isString } from '../utils/is-string/is-string.util';
 import { isFunction } from '../helpers/is-function/is-function.helper';
+import { ModelEndpoints } from '../interfaces/model-endpoints.interface';
 
 export abstract class HalModel {
 	private config: ModelOptions = this['config'] || DEFAULT_MODEL_OPTIONS;
@@ -85,6 +86,10 @@ export abstract class HalModel {
 
 	public get endpoint(): string {
 		return this.config.endpoint || 'unknownModelEndpoint';
+	}
+
+	public get modelEndpoints(): ModelEndpoints {
+		return null;
 	}
 
 	public get networkConfig(): NetworkConfig {

--- a/projects/ngx-hal/src/lib/services/datastore/datastore.service.ts
+++ b/projects/ngx-hal/src/lib/services/datastore/datastore.service.ts
@@ -881,35 +881,47 @@ export class DatastoreService {
 	private makePostRequest<T extends HalModel>(
 		url: string,
 		payload: object,
-		requestOptions: RequestOptions = {},
+		requestOptions?: RequestOptions,
 	): Observable<any> {
-		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(url, requestOptions);
+		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(
+			url,
+			requestOptions || {},
+		);
 		return this.http.post<T>(cleanUrl, payload, options as { [K: string]: any });
 	}
 
 	private makePutRequest<T extends HalModel>(
 		url: string,
 		payload: object,
-		requestOptions: RequestOptions = {},
+		requestOptions?: RequestOptions,
 	): Observable<any> {
-		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(url, requestOptions);
+		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(
+			url,
+			requestOptions || {},
+		);
 		return this.http.put<T>(cleanUrl, payload, options as { [K: string]: any });
 	}
 
 	private makePatchRequest<T extends HalModel>(
 		url: string,
 		payload: object,
-		requestOptions: RequestOptions = {},
+		requestOptions?: RequestOptions,
 	): Observable<any> {
-		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(url, requestOptions);
+		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(
+			url,
+			requestOptions || {},
+		);
 		return this.http.patch<T>(cleanUrl, payload, options as { [K: string]: any });
 	}
 
 	private makeDeleteRequest<T extends HalModel>(
 		url: string,
-		requestOptions: RequestOptions = {},
+		requestOptions?: RequestOptions,
 	): Observable<any> {
-		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(url, requestOptions);
+		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(
+			url,
+			requestOptions || {},
+		);
 		return this.http.delete<T>(cleanUrl, options as { [K: string]: any });
 	}
 

--- a/projects/ngx-hal/src/lib/services/datastore/datastore.service.ts
+++ b/projects/ngx-hal/src/lib/services/datastore/datastore.service.ts
@@ -893,7 +893,7 @@ export class DatastoreService {
 		requestOptions: RequestOptions = {},
 	): Observable<any> {
 		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(url, requestOptions);
-		return this.http.put<T>(url, payload, options as { [K: string]: any });
+		return this.http.put<T>(cleanUrl, payload, options as { [K: string]: any });
 	}
 
 	private makePatchRequest<T extends HalModel>(
@@ -902,7 +902,7 @@ export class DatastoreService {
 		requestOptions: RequestOptions = {},
 	): Observable<any> {
 		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(url, requestOptions);
-		return this.http.patch<T>(url, payload, options as { [K: string]: any });
+		return this.http.patch<T>(cleanUrl, payload, options as { [K: string]: any });
 	}
 
 	private makeDeleteRequest<T extends HalModel>(
@@ -910,7 +910,7 @@ export class DatastoreService {
 		requestOptions: RequestOptions = {},
 	): Observable<any> {
 		const { requestOptions: options, cleanUrl } = this.extractRequestInfo(url, requestOptions);
-		return this.http.delete<T>(url, options as { [K: string]: any });
+		return this.http.delete<T>(cleanUrl, options as { [K: string]: any });
 	}
 
 	private processRawResource<T extends HalModel>(

--- a/projects/ngx-hal/src/lib/types/request-options.type.ts
+++ b/projects/ngx-hal/src/lib/types/request-options.type.ts
@@ -13,6 +13,9 @@ export type RequestOptions = {
 				[param: string]: string | string[];
 		  }
 		| object;
+	routeParams?: {
+		[param: string]: string | string[];
+	};
 	reportProgress?: boolean;
 	responseType?;
 	withCredentials?: boolean;

--- a/projects/ngx-hal/src/public_api.ts
+++ b/projects/ngx-hal/src/public_api.ts
@@ -28,6 +28,7 @@ export * from './lib/decorators/header-attribute.decorator';
 export * from './lib/interfaces/has-many-options.interface';
 export * from './lib/interfaces/has-one-options.interface';
 export * from './lib/interfaces/custom-options.interface';
+export * from './lib/interfaces/model-endpoints.interface';
 
 export * from './lib/types/relationship-request-descriptor.type';
 


### PR DESCRIPTION
An additional way of providing model endpoints is implemented, `HalModel.modelEndpoints`, [wiki](https://github.com/infinum/ngx-hal/wiki/HalModel)

* `modelEndpoints`: `ModelEndpoints`
  * used for building resource URLs instead of `endpoint`
  * readonly
  * if provided, `singleResourceEndpoint` is used when:
    * fetching a resource via the `findOne` method
    * updating a resource via the `update` method
  * if provided, `collectionEndpoint` is used when:
    * fetching resources via the `find` method
    * creating a resource
  * both `singleResourceEndpoint` and `collectionEndpoint` support templated strings
    * templated parts of an URL will be replaced with `requestOptions.params` and `requestOptions.routeParams`
      * the difference between the two is that `routeParams` won't be sent in a request payload, they are used only for building templated URL
