### PR TITLE
Improve handling Pagination

### DIFF
--- a/projects/ngx-hal/package.json
+++ b/projects/ngx-hal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngx-hal",
-	"version": "3.1.1",
+	"version": "4.0.0-beta",
 	"description": "Angular library for supporting HAL format APIs",
 	"author": "Infinum <javascript.team@infinum.co>",
 	"license": "MIT",

--- a/projects/ngx-hal/src/lib/classes/hal-document.ts
+++ b/projects/ngx-hal/src/lib/classes/hal-document.ts
@@ -17,16 +17,16 @@ import { RequestOptions } from '../types/request-options.type';
 import { RelationshipRequestDescriptor } from '../types/relationship-request-descriptor.type';
 import { generateUUID } from '../helpers/uuid/uuid.helper';
 
-export class HalDocument<T extends HalModel> {
+export class HalDocument<T extends HalModel<P>, P extends Pagination> {
 	public models: Array<T>;
-	public pagination: Pagination;
+	public pagination: P;
 	public uniqueModelIdentificator: string;
 
 	constructor(
 		private rawResource: RawHalResource,
 		private rawResponse: HttpResponse<any>,
-		private modelClass: ModelConstructor<T>,
-		private datastore: DatastoreService,
+		private modelClass: ModelConstructor<T, P>,
+		private datastore: DatastoreService<P>,
 	) {
 		this.parseRawResources(rawResource);
 		this.generateUniqueModelIdentificator();
@@ -50,7 +50,7 @@ export class HalDocument<T extends HalModel> {
 		includeRelationships: Array<string | RelationshipRequestDescriptor> = [],
 		requestOptions: RequestOptions = {},
 		subsequentRequestsOptions: RequestOptions = {},
-	): Observable<HalDocument<T>> {
+	): Observable<HalDocument<T, P>> {
 		requestOptions.params = requestOptions.params || {};
 
 		if (pageNumber || pageNumber === 0) {
@@ -82,7 +82,7 @@ export class HalDocument<T extends HalModel> {
 		});
 	}
 
-	private generatePagination(pagination: RawHalResource): Pagination {
+	private generatePagination(pagination: RawHalResource): P {
 		if (!this.datastore.paginationClass) {
 			return null;
 		}

--- a/projects/ngx-hal/src/lib/classes/hal-storage/etag-hal-storage.ts
+++ b/projects/ngx-hal/src/lib/classes/hal-storage/etag-hal-storage.ts
@@ -1,22 +1,23 @@
-import { HalModel } from '../../models/hal.model';
-import { HalDocument } from './../hal-document';
 import { HttpResponse } from '@angular/common/http';
+import { HalModel } from '../../models/hal.model';
 import { RequestOptions } from '../../types/request-options.type';
-import { HalStorage } from './hal-storage';
 import { setRequestHeader } from '../../utils/set-request-header/set-request-header.util';
+import { Pagination } from '../pagination';
+import { HalDocument } from './../hal-document';
+import { HalStorage } from './hal-storage';
 
-export interface EtagStorageModel<T extends HalModel> {
-	model: T | HalDocument<T>;
+export interface EtagStorageModel<T extends HalModel<P>, P extends Pagination> {
+	model: T | HalDocument<T, P>;
 	etag: string;
 }
 
-export class EtagHalStorage extends HalStorage {
-	public save<T extends HalModel>(
-		model: T | HalDocument<T>,
+export class EtagHalStorage<P extends Pagination> extends HalStorage<P> {
+	public save<T extends HalModel<P>>(
+		model: T | HalDocument<T, P>,
 		response?: HttpResponse<T>,
 		alternateUniqueIdentificators: Array<string> = [],
-	): Array<EtagStorageModel<T>> {
-		const storedModels: Array<EtagStorageModel<T>> = [];
+	): Array<EtagStorageModel<T, P>> {
+		const storedModels: Array<EtagStorageModel<T, P>> = [];
 
 		const identificators: Array<string> = [].concat(alternateUniqueIdentificators);
 		identificators.push(model.uniqueModelIdentificator);
@@ -33,8 +34,8 @@ export class EtagHalStorage extends HalStorage {
 		return storedModels;
 	}
 
-	public get<T extends HalModel>(uniqueModelIdentificator: string): T | HalDocument<T> {
-		const localModel: EtagStorageModel<T> = this.getRawStorageModel(uniqueModelIdentificator);
+	public get<T extends HalModel<P>>(uniqueModelIdentificator: string): T | HalDocument<T, P> {
+		const localModel: EtagStorageModel<T, P> = this.getRawStorageModel(uniqueModelIdentificator);
 		return localModel ? localModel.model : undefined;
 	}
 
@@ -42,7 +43,8 @@ export class EtagHalStorage extends HalStorage {
 		uniqueModelIdentificator: string,
 		requestOptions: RequestOptions,
 	): void {
-		const storageModel: EtagStorageModel<any> = this.getRawStorageModel(uniqueModelIdentificator);
+		const storageModel: EtagStorageModel<any, P> =
+			this.getRawStorageModel(uniqueModelIdentificator);
 
 		if (!storageModel) {
 			return;
@@ -57,9 +59,9 @@ export class EtagHalStorage extends HalStorage {
 		}
 	}
 
-	protected getRawStorageModel<T extends HalModel>(
+	protected getRawStorageModel<T extends HalModel<P>>(
 		uniqueModelIdentificator: string,
-	): EtagStorageModel<T> {
+	): EtagStorageModel<T, P> {
 		return this.internalStorage[uniqueModelIdentificator];
 	}
 

--- a/projects/ngx-hal/src/lib/classes/hal-storage/hal-storage-factory.ts
+++ b/projects/ngx-hal/src/lib/classes/hal-storage/hal-storage-factory.ts
@@ -2,14 +2,15 @@ import { CacheStrategy } from '../../enums/cache-strategy.enum';
 import { SimpleHalStorage } from '../../classes/hal-storage/simple-hal-storage';
 import { EtagHalStorage } from '../../classes/hal-storage/etag-hal-storage';
 import { HalStorage } from './hal-storage';
+import { Pagination } from '../pagination';
 
-export type HalStorageType = SimpleHalStorage | EtagHalStorage;
+export type HalStorageType<P extends Pagination> = SimpleHalStorage<P> | EtagHalStorage<P>;
 
-export function createHalStorage(
+export function createHalStorage<P extends Pagination>(
 	cacheStrategy: CacheStrategy = CacheStrategy.NONE,
-	storageInstance: HalStorage,
-): HalStorageType {
-	let storage: HalStorageType;
+	storageInstance: HalStorage<P>,
+): HalStorageType<P> {
+	let storage: HalStorageType<P>;
 
 	switch (cacheStrategy) {
 		case CacheStrategy.NONE:

--- a/projects/ngx-hal/src/lib/classes/hal-storage/hal-storage.ts
+++ b/projects/ngx-hal/src/lib/classes/hal-storage/hal-storage.ts
@@ -1,22 +1,28 @@
-import { HalModel } from '../../models/hal.model';
-import { HalDocument } from './../hal-document';
 import { HttpResponse } from '@angular/common/http';
-import { RequestOptions } from '../../types/request-options.type';
 import { Observable } from 'rxjs';
+import { HalModel } from '../../models/hal.model';
 import { ModelConstructor, ModelConstructorFn } from '../../types/model-constructor.type';
+import { RequestOptions } from '../../types/request-options.type';
+import { Pagination } from '../pagination';
+import { HalDocument } from './../hal-document';
 
-export abstract class HalStorage {
+export abstract class HalStorage<P extends Pagination> {
 	protected internalStorage: { [K: string]: any } = {};
 
-	public abstract save<T extends HalModel>(
-		model: T | HalDocument<T>,
+	public abstract save<T extends HalModel<P>>(
+		model: T | HalDocument<T, P>,
 		response?: HttpResponse<T>,
 		alternateUniqueIdentificators?: Array<string>,
 	): void;
 
-	public abstract get<T extends HalModel>(uniqueModelIdentificator: string): T | HalDocument<T>;
+	public abstract get<T extends HalModel<P>>(
+		uniqueModelIdentificator: string,
+	): T | HalDocument<T, P>;
 
-	public saveAll<T extends HalModel>(models: Array<T>, savePartialModels: boolean = false): void {
+	public saveAll<T extends HalModel<P>>(
+		models: Array<T>,
+		savePartialModels: boolean = false,
+	): void {
 		models.forEach((model: T) => {
 			if (savePartialModels || !this.get(model.uniqueModelIdentificator)) {
 				this.save(model);
@@ -24,7 +30,7 @@ export abstract class HalStorage {
 		});
 	}
 
-	public remove(model: HalModel): void {
+	public remove(model: HalModel<P>): void {
 		delete this.internalStorage[model.uniqueModelIdentificator];
 	}
 
@@ -35,13 +41,13 @@ export abstract class HalStorage {
 		// noop
 	}
 
-	public makeGetRequestWrapper?<T extends HalModel>(
+	public makeGetRequestWrapper?<T extends HalModel<P>>(
 		urls: { originalUrl: string; cleanUrl: string; urlWithParams: string },
-		cachedResource: T | HalDocument<T>,
-		originalGetRequest$: Observable<T | HalDocument<T>>,
+		cachedResource: T | HalDocument<T, P>,
+		originalGetRequest$: Observable<T | HalDocument<T, P>>,
 		requestOptions: RequestOptions,
-		modelClass: ModelConstructor<T> | ModelConstructorFn<T>,
+		modelClass: ModelConstructor<T, P> | ModelConstructorFn<T, P>,
 		isSingleResource: boolean,
 		storePartialModels?: boolean,
-	): Observable<T | HalDocument<T>>;
+	): Observable<T | HalDocument<T, P>>;
 }

--- a/projects/ngx-hal/src/lib/classes/hal-storage/simple-hal-storage.ts
+++ b/projects/ngx-hal/src/lib/classes/hal-storage/simple-hal-storage.ts
@@ -2,10 +2,11 @@ import { HttpResponse } from '@angular/common/http';
 import { HalModel } from '../../models/hal.model';
 import { HalDocument } from './../hal-document';
 import { HalStorage } from './hal-storage';
+import { Pagination } from '../pagination';
 
-export class SimpleHalStorage extends HalStorage {
-	public save<T extends HalModel>(
-		model: T | HalDocument<T>,
+export class SimpleHalStorage<P extends Pagination> extends HalStorage<P> {
+	public save<T extends HalModel<P>>(
+		model: T | HalDocument<T, P>,
 		response?: HttpResponse<T>,
 		alternateUniqueIdentificators: Array<string> = [],
 	): void {
@@ -17,7 +18,7 @@ export class SimpleHalStorage extends HalStorage {
 		});
 	}
 
-	public get<T extends HalModel>(uniqueModelIdentificator: string): T | HalDocument<T> {
+	public get<T extends HalModel<P>>(uniqueModelIdentificator: string): T | HalDocument<T, P> {
 		return this.internalStorage[uniqueModelIdentificator];
 	}
 }

--- a/projects/ngx-hal/src/lib/decorators/attribute.decorator.ts
+++ b/projects/ngx-hal/src/lib/decorators/attribute.decorator.ts
@@ -1,3 +1,4 @@
+import { Pagination } from '../classes/pagination';
 import { ATTRIBUTE_PROPERTIES_METADATA_KEY } from '../constants/metadata.constant';
 import { ModelProperty as ModelPropertyEnum } from '../enums/model-property.enum';
 import { getObjProperty } from '../helpers/metadata/metadata.helper';
@@ -10,9 +11,12 @@ import { AttributeModelProperty } from '../interfaces/model-property.interface';
 import { HalModel } from '../models/hal.model';
 import { deepmergeWrapper } from '../utils/deepmerge-wrapper';
 
-export function Attribute(options: AttributeOptions = {}) {
-	return (model: HalModel, propertyName: string) => {
-		const attributeOptions: AttributeOptions = deepmergeWrapper(DEFAULT_ATTRIBUTE_OPTIONS, options);
+export function Attribute<P extends Pagination>(options: AttributeOptions<P> = {}) {
+	return (model: HalModel<P>, propertyName: string) => {
+		const attributeOptions: AttributeOptions<P> = deepmergeWrapper(
+			DEFAULT_ATTRIBUTE_OPTIONS,
+			options,
+		);
 		const existingAttributeProperties: Array<AttributeModelProperty> = getObjProperty(
 			model,
 			ATTRIBUTE_PROPERTIES_METADATA_KEY,

--- a/projects/ngx-hal/src/lib/decorators/datastore-config.decorator.ts
+++ b/projects/ngx-hal/src/lib/decorators/datastore-config.decorator.ts
@@ -1,10 +1,11 @@
-import { DatastoreOptions } from '../interfaces/datastore-options.interface';
+import { Pagination } from '../classes/pagination';
 import { HAL_DATASTORE_DOCUMENT_CLASS_METADATA_KEY } from '../constants/metadata.constant';
+import { setObjProperty } from '../helpers/metadata/metadata.helper';
+import { DatastoreOptions } from '../interfaces/datastore-options.interface';
 import { DEFAULT_NETWORK_CONFIG, NetworkConfig } from '../interfaces/network-config.interface';
 import { deepmergeWrapper } from '../utils/deepmerge-wrapper';
-import { setObjProperty } from '../helpers/metadata/metadata.helper';
 
-export function DatastoreConfig(config: DatastoreOptions) {
+export function DatastoreConfig<P extends Pagination>(config: DatastoreOptions<P>) {
 	return function (target: any) {
 		const networkConfig = deepmergeWrapper<NetworkConfig>(
 			DEFAULT_NETWORK_CONFIG,

--- a/projects/ngx-hal/src/lib/decorators/has-many.decorator.ts
+++ b/projects/ngx-hal/src/lib/decorators/has-many.decorator.ts
@@ -1,3 +1,4 @@
+import { Pagination } from '../classes/pagination';
 import { HAS_MANY_PROPERTIES_METADATA_KEY } from '../constants/metadata.constant';
 import { ModelProperty } from '../enums/model-property.enum';
 import { getObjProperty } from '../helpers/metadata/metadata.helper';
@@ -7,9 +8,9 @@ import { HasManyModelProperty } from '../interfaces/model-property.interface';
 import { HalModel } from '../models/hal.model';
 import { deepmergeWrapper } from '../utils/deepmerge-wrapper';
 
-export function HasMany(options: HasManyOptions) {
-	return (model: HalModel, propertyName: string) => {
-		const hasManyOptions: HasManyOptions = deepmergeWrapper(DEFAULT_HAS_MANY_OPTIONS, options);
+export function HasMany<P extends Pagination>(options: HasManyOptions<P>) {
+	return (model: HalModel<P>, propertyName: string) => {
+		const hasManyOptions: HasManyOptions<P> = deepmergeWrapper(DEFAULT_HAS_MANY_OPTIONS, options);
 
 		const existingHasManyProperties: Array<HasManyModelProperty> = getObjProperty(
 			model,

--- a/projects/ngx-hal/src/lib/decorators/has-one.decorator.ts
+++ b/projects/ngx-hal/src/lib/decorators/has-one.decorator.ts
@@ -1,3 +1,4 @@
+import { Pagination } from '../classes/pagination';
 import { HAS_ONE_PROPERTIES_METADATA_KEY } from '../constants/metadata.constant';
 import { ModelProperty } from '../enums/model-property.enum';
 import { getObjProperty } from '../helpers/metadata/metadata.helper';
@@ -7,9 +8,9 @@ import { HasOneModelProperty } from '../interfaces/model-property.interface';
 import { HalModel } from '../models/hal.model';
 import { deepmergeWrapper } from '../utils/deepmerge-wrapper';
 
-export function HasOne(options: HasOneOptions) {
-	return (model: HalModel, propertyName: string) => {
-		const hasOneOptions: HasOneOptions = deepmergeWrapper(DEFAULT_HAS_ONE_OPTIONS, options);
+export function HasOne<P extends Pagination>(options: HasOneOptions<P>) {
+	return (model: HalModel<P>, propertyName: string) => {
+		const hasOneOptions: HasOneOptions<P> = deepmergeWrapper(DEFAULT_HAS_ONE_OPTIONS, options);
 
 		const existingHasOneProperties: Array<HasOneModelProperty> = getObjProperty(
 			model,

--- a/projects/ngx-hal/src/lib/decorators/header-attribute.decorator.ts
+++ b/projects/ngx-hal/src/lib/decorators/header-attribute.decorator.ts
@@ -1,3 +1,4 @@
+import { Pagination } from '../classes/pagination';
 import { HEADER_ATTRIBUTE_PROPERTIES_METADATA_KEY } from '../constants/metadata.constant';
 import { ModelProperty as ModelPropertyEnum } from '../enums/model-property.enum';
 import { getObjProperty } from '../helpers/metadata/metadata.helper';
@@ -13,9 +14,9 @@ import {
 import { HalModel } from '../models/hal.model';
 import { deepmergeWrapper } from '../utils/deepmerge-wrapper';
 
-export function HeaderAttribute(options: HeaderAttributeOptions = {}) {
-	return (model: HalModel, propertyName: string) => {
-		const headerAttributeOptions: HeaderAttributeOptions = deepmergeWrapper(
+export function HeaderAttribute<P extends Pagination>(options: HeaderAttributeOptions<P> = {}) {
+	return (model: HalModel<P>, propertyName: string) => {
+		const headerAttributeOptions: HeaderAttributeOptions<P> = deepmergeWrapper(
 			DEFAULT_HEADER_ATTRIBUTE_OPTIONS,
 			options,
 		);

--- a/projects/ngx-hal/src/lib/decorators/link.decorator.ts
+++ b/projects/ngx-hal/src/lib/decorators/link.decorator.ts
@@ -1,3 +1,4 @@
+import { Pagination } from '../classes/pagination';
 import { LINK_PROPERTIES_METADATA_KEY } from '../constants/metadata.constant';
 import { ModelProperty } from '../enums/model-property.enum';
 import { getObjProperty } from '../helpers/metadata/metadata.helper';
@@ -6,8 +7,8 @@ import { LinkRelationshipOptions } from '../interfaces/link-relationship-options
 import { LinkProperty } from '../interfaces/model-property.interface';
 import { HalModel } from '../models/hal.model';
 
-export function Link(options: LinkRelationshipOptions = {}) {
-	return (model: HalModel, propertyName: string) => {
+export function Link<P extends Pagination>(options: LinkRelationshipOptions = {}) {
+	return (model: HalModel<P>, propertyName: string) => {
 		const existingLinkProperties: Array<LinkProperty> = getObjProperty(
 			model,
 			LINK_PROPERTIES_METADATA_KEY,

--- a/projects/ngx-hal/src/lib/decorators/model-config.decorator.ts
+++ b/projects/ngx-hal/src/lib/decorators/model-config.decorator.ts
@@ -1,11 +1,12 @@
-import { ModelOptions, DEFAULT_MODEL_OPTIONS } from '../interfaces/model-options.interface';
+import { Pagination } from '../classes/pagination';
 import { HAL_MODEL_DOCUMENT_CLASS_METADATA_KEY } from '../constants/metadata.constant';
-import { deepmergeWrapper } from '../utils/deepmerge-wrapper';
 import { setObjProperty } from '../helpers/metadata/metadata.helper';
+import { DEFAULT_MODEL_OPTIONS, ModelOptions } from '../interfaces/model-options.interface';
+import { deepmergeWrapper } from '../utils/deepmerge-wrapper';
 
-export function ModelConfig(config: ModelOptions) {
+export function ModelConfig<P extends Pagination>(config: ModelOptions<P>) {
 	return function (target: any) {
-		const configValue = deepmergeWrapper<ModelOptions>(DEFAULT_MODEL_OPTIONS, config);
+		const configValue = deepmergeWrapper<ModelOptions<P>>(DEFAULT_MODEL_OPTIONS, config);
 		Object.defineProperty(target.prototype, 'config', {
 			value: configValue,
 			writable: true,

--- a/projects/ngx-hal/src/lib/interfaces/attribute-options.interface.ts
+++ b/projects/ngx-hal/src/lib/interfaces/attribute-options.interface.ts
@@ -1,7 +1,8 @@
+import { Pagination } from '../classes/pagination';
 import { ModelConstructor, ModelConstructorFn } from '../types/model-constructor.type';
 
-export interface AttributeOptions {
-	useClass?: string | ModelConstructor<any> | ModelConstructorFn<any>;
+export interface AttributeOptions<P extends Pagination> {
+	useClass?: string | ModelConstructor<any, P> | ModelConstructorFn<any, P>;
 	transformResponseValue?: (rawAttribute: any) => any;
 	transformBeforeSave?: (raw: any) => any;
 	externalName?: string;

--- a/projects/ngx-hal/src/lib/interfaces/datastore-options.interface.ts
+++ b/projects/ngx-hal/src/lib/interfaces/datastore-options.interface.ts
@@ -1,14 +1,14 @@
 import { NetworkConfig } from './network-config.interface';
 import { HalModel } from '../models/hal.model';
 import { HalDocumentConstructor } from '../types/hal-document-construtor.type';
-import { PaginationConstructor } from '../types/pagination.type';
 import { CacheStrategy } from '../enums/cache-strategy.enum';
 import { HalStorage } from '../classes/hal-storage/hal-storage';
+import { Pagination } from '../classes/pagination';
 
-export interface DatastoreOptions {
+export interface DatastoreOptions<P extends Pagination> {
 	network?: NetworkConfig;
-	halDocumentClass?: HalDocumentConstructor<HalModel>;
-	paginationClass?: PaginationConstructor;
+	halDocumentClass?: HalDocumentConstructor<HalModel<P>, P>;
+	paginationClass?: { new (...args): P };
 	cacheStrategy?: CacheStrategy;
-	storage?: HalStorage;
+	storage?: HalStorage<P>;
 }

--- a/projects/ngx-hal/src/lib/interfaces/has-many-options.interface.ts
+++ b/projects/ngx-hal/src/lib/interfaces/has-many-options.interface.ts
@@ -1,7 +1,8 @@
+import { Pagination } from '../classes/pagination';
 import { ModelConstructor, ModelConstructorFn } from '../types/model-constructor.type';
 
-export interface HasManyOptions {
-	itemsType: string | ModelConstructor<any> | ModelConstructorFn<any>;
+export interface HasManyOptions<P extends Pagination> {
+	itemsType: string | ModelConstructor<any, P> | ModelConstructorFn<any, P>;
 	includeInPayload?: boolean;
 	externalName?: string;
 }

--- a/projects/ngx-hal/src/lib/interfaces/has-one-options.interface.ts
+++ b/projects/ngx-hal/src/lib/interfaces/has-one-options.interface.ts
@@ -1,9 +1,10 @@
+import { Pagination } from '../classes/pagination';
 import { ModelConstructor, ModelConstructorFn } from '../types/model-constructor.type';
 
-export interface HasOneOptions {
+export interface HasOneOptions<P extends Pagination> {
 	externalName?: string;
 	includeInPayload?: boolean;
-	propertyClass: string | ModelConstructor<any> | ModelConstructorFn<any>;
+	propertyClass: string | ModelConstructor<any, P> | ModelConstructorFn<any, P>;
 }
 
 export const DEFAULT_HAS_ONE_OPTIONS = {

--- a/projects/ngx-hal/src/lib/interfaces/header-attribute-options.interface.ts
+++ b/projects/ngx-hal/src/lib/interfaces/header-attribute-options.interface.ts
@@ -1,7 +1,8 @@
+import { Pagination } from '../classes/pagination';
 import { ModelConstructor, ModelConstructorFn } from '../types/model-constructor.type';
 
-export interface HeaderAttributeOptions {
-	useClass?: boolean | ModelConstructor<any> | ModelConstructorFn<any>;
+export interface HeaderAttributeOptions<P extends Pagination> {
+	useClass?: boolean | ModelConstructor<any, P> | ModelConstructorFn<any, P>;
 	transformResponseValue?: (rawAttribute: any) => any;
 	transformBeforeSave?: (raw: any) => any;
 	externalName?: string;

--- a/projects/ngx-hal/src/lib/interfaces/model-options.interface.ts
+++ b/projects/ngx-hal/src/lib/interfaces/model-options.interface.ts
@@ -1,15 +1,16 @@
 import { HalDocumentConstructor } from '../types/hal-document-construtor.type';
 import { HalModel } from '../models/hal.model';
 import { NetworkConfig } from './network-config.interface';
+import { Pagination } from '../classes/pagination';
 
-export class ModelOptions {
+export class ModelOptions<P extends Pagination> {
 	type: string;
 	endpoint?: string;
-	halDocumentClass?: HalDocumentConstructor<HalModel>;
+	halDocumentClass?: HalDocumentConstructor<HalModel<P>, P>;
 	networkConfig?: NetworkConfig;
 }
 
-export const DEFAULT_MODEL_OPTIONS: ModelOptions = {
+export const DEFAULT_MODEL_OPTIONS: ModelOptions<any> = {
 	type: '',
 };
 

--- a/projects/ngx-hal/src/lib/services/model-service/model.service.ts
+++ b/projects/ngx-hal/src/lib/services/model-service/model.service.ts
@@ -6,9 +6,13 @@ import { RequestOptions } from '../../types/request-options.type';
 import { HalDocument } from '../../classes/hal-document';
 import { ModelConstructor } from '../../types/model-constructor.type';
 import { RelationshipRequestDescriptor } from '../../types/relationship-request-descriptor.type';
+import { Pagination } from '../../classes/pagination';
 
-export abstract class ModelService<Model extends HalModel> {
-	constructor(protected datastore: DatastoreService, private modelClass: ModelConstructor<Model>) {}
+export abstract class ModelService<Model extends HalModel<P>, P extends Pagination> {
+	constructor(
+		protected datastore: DatastoreService<P>,
+		private modelClass: ModelConstructor<Model, P>,
+	) {}
 
 	public findOne(
 		modelId: string,
@@ -37,7 +41,7 @@ export abstract class ModelService<Model extends HalModel> {
 	public find(
 		params: object | { [param: string]: string | string[] } | HttpParams,
 		includeMeta: true,
-	): Observable<HalDocument<Model>>;
+	): Observable<HalDocument<Model, P>>;
 	public find(
 		params: object | { [param: string]: string | string[] } | HttpParams,
 		includeMeta: false,
@@ -47,7 +51,7 @@ export abstract class ModelService<Model extends HalModel> {
 		params: object | { [param: string]: string | string[] } | HttpParams,
 		includeMeta: true,
 		includeRelationships: Array<string | RelationshipRequestDescriptor>,
-	): Observable<HalDocument<Model>>;
+	): Observable<HalDocument<Model, P>>;
 	public find(
 		params: object | { [param: string]: string | string[] } | HttpParams,
 		includeMeta: false,
@@ -59,7 +63,7 @@ export abstract class ModelService<Model extends HalModel> {
 		includeMeta: true,
 		includeRelationships: Array<string | RelationshipRequestDescriptor>,
 		requestOptions: RequestOptions,
-	): Observable<HalDocument<Model>>;
+	): Observable<HalDocument<Model, P>>;
 	public find(
 		params: object | { [param: string]: string | string[] } | HttpParams,
 		includeMeta: true,
@@ -68,7 +72,7 @@ export abstract class ModelService<Model extends HalModel> {
 		subsequentRequestsOptions: RequestOptions,
 		customUrl?: string,
 		storePartialModels?: boolean,
-	): Observable<HalDocument<Model>>;
+	): Observable<HalDocument<Model, P>>;
 	public find(
 		params: object | { [param: string]: string | string[] } | HttpParams,
 		includeMeta: false,
@@ -86,7 +90,7 @@ export abstract class ModelService<Model extends HalModel> {
 		subsequentRequestsOptions: RequestOptions = {},
 		customUrl?: string,
 		storePartialModels?: boolean,
-	): Observable<HalDocument<Model> | Array<Model>> {
+	): Observable<HalDocument<Model, P> | Array<Model>> {
 		return this.datastore.find(
 			this.modelClass,
 			params,

--- a/projects/ngx-hal/src/lib/types/hal-document-construtor.type.ts
+++ b/projects/ngx-hal/src/lib/types/hal-document-construtor.type.ts
@@ -1,6 +1,7 @@
 import { HalModel } from '../models/hal.model';
 import { HalDocument } from '../classes/hal-document';
+import { Pagination } from '../classes/pagination';
 
-export type HalDocumentConstructor<T extends HalModel> = {
-	new (...args): HalDocument<T>;
+export type HalDocumentConstructor<T extends HalModel<P>, P extends Pagination> = {
+	new (...args): HalDocument<T, P>;
 };

--- a/projects/ngx-hal/src/lib/types/model-constructor.type.ts
+++ b/projects/ngx-hal/src/lib/types/model-constructor.type.ts
@@ -1,4 +1,7 @@
+import { Pagination } from '../classes/pagination';
 import { HalModel } from '../models/hal.model';
 
-export type ModelConstructor<T extends HalModel> = { new (...args): T };
-export type ModelConstructorFn<T extends HalModel> = (rawPropertyValue: any) => ModelConstructor<T>;
+export type ModelConstructor<T extends HalModel<P>, P extends Pagination> = { new (...args): T };
+export type ModelConstructorFn<T extends HalModel<P>, P extends Pagination> = (
+	rawPropertyValue: any,
+) => ModelConstructor<T, P>;

--- a/projects/ngx-hal/src/lib/types/pagination.type.ts
+++ b/projects/ngx-hal/src/lib/types/pagination.type.ts
@@ -1,3 +1,0 @@
-import { Pagination } from '../classes/pagination';
-
-export type PaginationConstructor = { new (...args): Pagination };


### PR DESCRIPTION
### Description

The pull request introduces a required type for defining pagination.
The `datastore` service (and other `ngx-hal` constructs) is now a generic class that accepts a required Pagination type.
More can be checked in the [Update guide](https://github.com/infinum/ngx-hal/wiki/UpdateGuide), `Update to 4.0.0`.
Also, [Getting started](https://github.com/infinum/ngx-hal/wiki/Getting-started) section has been adapted to the changes from this pull request.