### PR TITLE
Remove URI malformed console noise

### DIFF
--- a/projects/ngx-hal/src/lib/helpers/make-query-params-string/make-query-params-string.helper.ts
+++ b/projects/ngx-hal/src/lib/helpers/make-query-params-string/make-query-params-string.helper.ts
@@ -7,7 +7,12 @@ export function makeQueryParamsString(params: object, sortAlphabetically: boolea
 
 	const queryParamsString: string = paramKeys.reduce(
 		(paramsString: string, queryParamKey: string) => {
-			return `${paramsString}&${queryParamKey}=${params[queryParamKey]}`;
+			const paramValue: string | Array<string> = params[queryParamKey];
+			const encodedValue: string = Array.isArray(paramValue)
+				? paramValue.map((item: string) => encodeURIComponent(item)).join(',')
+				: encodeURIComponent(String(paramValue));
+
+			return `${paramsString}&${queryParamKey}=${encodedValue}`;
 		},
 		'',
 	);

--- a/projects/ngx-hal/src/lib/utils/get-query-params/get-query-params.util.spec.ts
+++ b/projects/ngx-hal/src/lib/utils/get-query-params/get-query-params.util.spec.ts
@@ -41,10 +41,16 @@ describe('getQueryParams', () => {
 	});
 
 	it('should fallback to the original value of a query parameter if decoding is not possible', () => {
-		spyOn(console, 'error').and.stub();
 		const result = getQueryParams('test.com?firstParameter=%E0%A4%A');
 		expect(result).toEqual({
 			firstParameter: '%E0%A4%A',
+		});
+	});
+
+	it('should properly decode query parameter containing a percentage sign', () => {
+		const result = getQueryParams('test.com?firstParameter=animal%25');
+		expect(result).toEqual({
+			firstParameter: 'animal%',
 		});
 	});
 

--- a/projects/ngx-hal/src/lib/utils/get-query-params/get-query-params.util.ts
+++ b/projects/ngx-hal/src/lib/utils/get-query-params/get-query-params.util.ts
@@ -38,8 +38,7 @@ export function decodeURIComponentWithErrorHandling(value: string): string {
 	}
 	try {
 		return decodeURIComponent(value);
-	} catch (e) {
-		console.error(e);
+	} catch {
 		return value;
 	}
 }


### PR DESCRIPTION
Query param values with a literal % (e.g. "Cooking cream (15% fat)" caused `URIError: URI malformed` in the console when ngx-hal parsed internal URL strings for cache lookups. Requests still worked, but the error came from `decodeURIComponentWithErrorHandling` logging handled failures, combined with `makeQueryParamsString` building unencoded `urlWithParams` strings.

Before/after:

https://github.com/user-attachments/assets/92badc4c-579d-481d-8a20-6dc1f573f095

